### PR TITLE
Improve simd search (25% improvement)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -255,21 +255,15 @@ fn update_stats(stats: &mut HashMap<StrVec, Stat, FastHasherBuilder>, station: &
 
 // SAFETY: buffer must contain a semicolon in the last min(8, buffer.len()) bytes
 unsafe fn split_at_semicolon(buffer: &[u8]) -> (&[u8], &[u8]) {
-    const LANES: usize = 8;
-    const SPLAT: Simd<u8, LANES> = Simd::splat(b';');
-
-    let bytes = if let Some(chunk) = buffer.last_chunk() {
-        Simd::<u8, LANES>::from_array(*chunk)
-    } else {
-        std::hint::cold_path();
-        Simd::<u8, LANES>::load_or_default(buffer)
-    };
-
-    let set_pos = unsafe { bytes.simd_eq(SPLAT).first_set().unwrap_unchecked() };
-    // there is no Mask::last_set, but we know there's only 1 ;
-    let pos = buffer.len() - LANES + set_pos;
-    let (before, after) = unsafe { buffer.split_at_unchecked(pos + 1) };
-    (&before[..before.len() - 1], after)
+    let mut pos = buffer.len() - 4;
+    unsafe {
+        // SAFETY: readme promises there will be a semicolon
+        while *buffer.get_unchecked(pos) != b';' {
+            pos -= 1;
+        }
+        let (before, after) = buffer.split_at_unchecked(pos + 1);
+        (&before[..before.len() - 1], after)
+    }
 }
 
 pub fn find_newline(mut buffer: &[u8]) -> Option<usize> {


### PR DESCRIPTION
Replace semi_at and next_newline with a simpler (and seemingly significantly faster) simd search.

I define a `find_byte` function which is generic over the number of SIMD lanes. I then select lane sizes for the newline and semicolon searches that minimize total time (on my machine anyway) which wound up being significantly smaller than the previous choice of 64.

I suspect this is because newlines and (especially) semicolons are often found relatively early and using a smaller number of lanes improves latency (at the hypothetical cost of throughput).

This also removes the need for `memchr` (calling it on the slow path yields no discernable difference).