### PR TITLE
Poor man's work stealing queue (30%-60% improvement depending on number of cores)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -255,21 +255,15 @@ fn update_stats(stats: &mut HashMap<StrVec, Stat, FastHasherBuilder>, station: &
 
 // SAFETY: buffer must contain a semicolon in the last min(8, buffer.len()) bytes
 unsafe fn split_at_semicolon(buffer: &[u8]) -> (&[u8], &[u8]) {
-    const LANES: usize = 8;
-    const SPLAT: Simd<u8, LANES> = Simd::splat(b';');
-
-    let bytes = if let Some(chunk) = buffer.last_chunk() {
-        Simd::<u8, LANES>::from_array(*chunk)
-    } else {
-        std::hint::cold_path();
-        Simd::<u8, LANES>::load_or_default(buffer)
-    };
-
-    let set_pos = unsafe { bytes.simd_eq(SPLAT).first_set().unwrap_unchecked() };
-    // there is no Mask::last_set, but we know there's only 1 ;
-    let pos = buffer.len() - LANES + set_pos;
-    let (before, after) = unsafe { buffer.split_at_unchecked(pos + 1) };
-    (&before[..before.len() - 1], after)
+    let mut pos = buffer.len() - 4;
+    unsafe {
+        // SAFETY: readme promises there will be a semicolon
+        while *buffer.get_unchecked(pos) != b';' {
+            pos -= 1;
+        }
+        let (before, after) = buffer.split_at_unchecked(pos + 1);
+        (&before[..before.len() - 1], after)
+    }
 }
 
 pub fn find_newline(mut buffer: &[u8]) -> Option<usize> {


### PR DESCRIPTION
This is adapted from [my own](https://github.com/cmlsharp/onebrc) solution to this challenge. It builds atop https://github.com/jonhoo/brrr/pull/2 .  I would have preferred to keep PRs independent, but the efficiency of this change requires newline searching to be faster.

It makes the following changes:
* Rather than dividing up the file into  large chunks and assigning each chunk to a thread, the file is divided into smaller 64KB blocks which worker threads "claim" by incrementing a shared AtomicU64 (I have no theoretical justification for 64KB, it's just what seemed to maximize speed, I suppose smaller values would increase contention on the counter). Worker threads read a bit more than 64KB to ensure they can always start from the beginning of a line.
* It eschews memory mapping in favor of raw 64KB reads. I attempted to maintain memory mapping, but it seemed strictly slower. All threads  open separate file descriptors. I also attempted to have them share a single file descriptor and use  `pread` (via `read_at_exact`) but this was marginally slower.

The speedup here seems to depend heavily on the number of cores. On a very powerful machine with 128 logical cores, this yielded a 60% improvement relative to https://github.com/jonhoo/brrr/pull/2. When limiting to 8 cores, it was closer to a 30% improvement on that same machine.

It would be interesting to fully disambiguate what fraction of this improvement is from the "AtomicU64" change and which is from the "fixed sized reads of 64KB" vs memory mapping. I did try a version of this approach with memory mapping as mentioned above and it was slower, but I do not remember by how much.