### PR TITLE
Add even-odds map to reduce key collision

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,8 +230,8 @@ fn print(stats: BTreeMap<String, Stat>) {
 #[inline(never)]
 fn one(map: &[u8]) -> HashMap<StrVec, Stat, FastHasherBuilder> {
     let mut stats: [HashMap<StrVec, Stat, FastHasherBuilder>; 2] = [
-        HashMap::with_capacity_and_hasher(1024 / 2, FastHasherBuilder),
-        HashMap::with_capacity_and_hasher(1024 / 2, FastHasherBuilder),
+        HashMap::with_capacity_and_hasher(1024, FastHasherBuilder),
+        HashMap::with_capacity_and_hasher(1024, FastHasherBuilder),
     ];
 
     let mut at = 0;
@@ -243,8 +243,8 @@ fn one(map: &[u8]) -> HashMap<StrVec, Stat, FastHasherBuilder> {
         let station = unsafe { line.get_unchecked(..semi) };
         let temperature = unsafe { line.get_unchecked(semi + 1..) };
         let t = parse_temperature(temperature);
-        let bucket = unsafe { stats.get_unchecked_mut(station.len() & 1) };
 
+        let bucket = unsafe { stats.get_unchecked_mut(station.len() & 1) };
         update_stats(bucket, station, t);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,11 @@ fn print(stats: BTreeMap<String, Stat>) {
 
 #[inline(never)]
 fn one(map: &[u8]) -> HashMap<StrVec, Stat, FastHasherBuilder> {
-    let mut stats = HashMap::with_capacity_and_hasher(1_024, FastHasherBuilder);
+    let mut stats: [HashMap<StrVec, Stat, FastHasherBuilder>; 2] = [
+        HashMap::with_capacity_and_hasher(1024 / 2, FastHasherBuilder),
+        HashMap::with_capacity_and_hasher(1024 / 2, FastHasherBuilder),
+    ];
+
     let mut at = 0;
     while at < map.len() {
         let newline_at = at + next_newline(map, at);
@@ -239,9 +243,14 @@ fn one(map: &[u8]) -> HashMap<StrVec, Stat, FastHasherBuilder> {
         let station = unsafe { line.get_unchecked(..semi) };
         let temperature = unsafe { line.get_unchecked(semi + 1..) };
         let t = parse_temperature(temperature);
-        update_stats(&mut stats, station, t);
+        let bucket = unsafe { stats.get_unchecked_mut(station.len() & 1) };
+
+        update_stats(bucket, station, t);
     }
-    stats
+
+    let [mut s0, mut s1] = stats;
+    s0.extend(s1.drain());
+    s0
 }
 
 fn update_stats(stats: &mut HashMap<StrVec, Stat, FastHasherBuilder>, station: &[u8], t: i16) {


### PR DESCRIPTION
This change replaces the single HashMap with two sharded maps, selected using a branchless even/odd check.

Splitting keys across two buckets reduces collision pressure and improves lookup performance.
On my machine, runtime dropped from ~1450–1500 ms to ~1350-1400ms.
