### PR TITLE
Faster split_at_semicolon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -286,16 +286,23 @@ fn update_stats(stats: &mut HashMap<StrVec, Stat, FastHasherBuilder>, station: &
     stats.count += 1;
 }
 
-// SAFETY: buffer must contain a semicolon in the last min(8, buffer.len()) bytes
+// SAFETY: semicolon is either found at buffer[buffer.len()-4] or buffer[buffer.len()-5]
+//         otherwise is assumed to be at buffer[buffer.len()-6]
 unsafe fn split_at_semicolon(buffer: &[u8]) -> (&[u8], &[u8]) {
     let mut pos = buffer.len() - 4;
     unsafe {
-        // SAFETY: readme promises there will be a semicolon
-        while *buffer.get_unchecked(pos) != b';' {
-            pos -= 1;
-        }
+        let mut total = 0;
+        let mut found = *buffer.get_unchecked(pos) == b';';
+        if !found {
+            total += 1
+        };
+        found |= *buffer.get_unchecked(pos - 1) == b';';
+        if !found {
+            total += 1
+        };
+        pos = pos - total;
         let (before, after) = buffer.split_at_unchecked(pos + 1);
-        (&before[..before.len() - 1], after)
+        (before.get_unchecked(..before.len() - 1), after)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,16 +291,10 @@ fn update_stats(stats: &mut HashMap<StrVec, Stat, FastHasherBuilder>, station: &
 unsafe fn split_at_semicolon(buffer: &[u8]) -> (&[u8], &[u8]) {
     let mut pos = buffer.len() - 4;
     unsafe {
-        let mut total = 0;
-        let mut found = *buffer.get_unchecked(pos) == b';';
-        if !found {
-            total += 1
-        };
-        found |= *buffer.get_unchecked(pos - 1) == b';';
-        if !found {
-            total += 1
-        };
-        pos = pos - total;
+        let not_found1 = (*buffer.get_unchecked(pos) != b';') as usize;
+        let not_found2 = (*buffer.get_unchecked(pos - 1) != b';') as usize;
+        pos = pos - (not_found1 + (not_found1 & not_found2));
+
         let (before, after) = buffer.split_at_unchecked(pos + 1);
         (before.get_unchecked(..before.len() - 1), after)
     }


### PR DESCRIPTION
The semicolon is either found at buffer[buffer.len()-4] or buffer[buffer.len()-5], otherwise is assumed to be at buffer[buffer.len()-6]. About 5% faster overall with no looping.

Buffer always has length >= 5 characters, because station name has a least 1 byte and there's a semicolon, so it's safe to check at buffer.len()-5.