### PR TITLE
Slightly optimized print

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -227,31 +227,30 @@ fn main() {
     print(stats);
 }
 
+macro_rules! display_stat {
+    ($entry:expr) => {
+        format_args!(
+            "{}={:.1}/{:.1}/{:.1}",
+            $entry.0,
+            ($entry.1.min as f64) / 10.,
+            ($entry.1.sum as f64) / 10. / ($entry.1.count as f64),
+            ($entry.1.max as f64) / 10.
+        )
+    };
+}
+
 #[inline(never)]
 fn print(stats: BTreeMap<String, Stat>) {
     let stdout = std::io::stdout();
     let stdout = stdout.lock();
     let mut writer = std::io::BufWriter::new(stdout);
-    write!(writer, "{{").unwrap();
-    let stats = BTreeMap::from_iter(
-        stats
-            .iter()
-            // SAFETY: the README promised
-            .map(|(k, v)| (unsafe { std::str::from_utf8_unchecked(k.as_ref()) }, *v)),
-    );
-    let mut stats = stats.into_iter().peekable();
-    while let Some((station, stat)) = stats.next() {
-        write!(
-            writer,
-            "{station}={:.1}/{:.1}/{:.1}",
-            (stat.min as f64) / 10.,
-            (stat.sum as f64) / 10. / (stat.count as f64),
-            (stat.max as f64) / 10.
-        )
-        .unwrap();
-        if stats.peek().is_some() {
-            write!(writer, ", ").unwrap();
-        }
+    let mut stats = stats.into_iter();
+    let Some(first) = stats.next() else {
+        return write!(writer, "{{}}").unwrap();
+    };
+    write!(writer, "{{{}", display_stat!(first)).unwrap();
+    for entry in stats {
+        write!(writer, ", {}", display_stat!(entry)).unwrap();
     }
     write!(writer, "}}").unwrap();
 }


### PR DESCRIPTION
When converting the code to use multiple threads in the live stream it was needed to convert `StrVec` keys into an owned type, `String` when receiving chunks processed by threads. Thus making the latter `str::from_utf8` mapping from within `print`, for ordering btree map keys, no longer necessary. 

Also by special casing the `is_empty` condition of the btree map we are able to avoid placing commas depending if there is a next element in the iterator.

This provided a negligible ~0.05s run time improvement on my machine (8c/16t). Though I am not sure if there is a better way to avoid code duplication other than using `format_args!` that would result in more efficient assembly. 