### PR TITLE
feat(simd-split-at-semicolon): Semicolon index calculation using SIMD (~= 10%)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -288,12 +288,17 @@ fn update_stats(stats: &mut HashMap<StrVec, Stat, FastHasherBuilder>, station: &
 
 // SAFETY: buffer must contain a semicolon in the last min(8, buffer.len()) bytes
 unsafe fn split_at_semicolon(buffer: &[u8]) -> (&[u8], &[u8]) {
-    let mut pos = buffer.len() - 4;
+    const SPLAT: Simd<u8, LANES> = Simd::splat(b';');
+    const LANES: usize = 4;
+
     unsafe {
-        // SAFETY: readme promises there will be a semicolon
-        while *buffer.get_unchecked(pos) != b';' {
-            pos -= 1;
-        }
+        let start = buffer.len() - 7;
+        let end = buffer.len() - 4;
+        let bytes = Simd::<u8, LANES>::from_slice(&buffer[start..=end]);
+
+        // SAFETY: Readme promises there will be a semicolon
+        let pos = start + bytes.simd_eq(SPLAT).first_set().unwrap_unchecked();
+
         let (before, after) = buffer.split_at_unchecked(pos + 1);
         (&before[..before.len() - 1], after)
     }
@@ -314,8 +319,7 @@ pub fn find_newline(mut buffer: &[u8]) -> Option<usize> {
         buffer = rest;
     }
 
-    let bytes = Simd::<u8, LANES>::load_or_default(buffer);
-    bytes.simd_eq(SPLAT).first_set().map(|set| set + i)
+    buffer.iter().position(|&b| b == b'\n').map(|pos| pos + i)
 }
 
 #[inline]


### PR DESCRIPTION
SIMD works best when we don’t need extra assumptions or manual data alignment, and when all calculations are data simple pipeline transformations.

Thanks to the guarantees discussed in https://github.com/jonhoo/brrr/pull/2#issuecomment-3608170193  about where the ; can appear (between buffer_len - 7 and buffer_len - 4), we can safely use a u8x4 SIMD search and get his max power.

With this change, the computation time goes below 700 milliseconds.

Before
<img width="299" height="121" alt="image" src="https://github.com/user-attachments/assets/d4859bac-357f-420d-b354-0d3e55e6b17f" />

After
<img width="276" height="108" alt="image" src="https://github.com/user-attachments/assets/8f008ffb-6acb-4c4e-b588-55082ed22d5c" />

I also made a small change in find_new_line(), related to an edge case.
When there are no more aligned-lane chunks, it is usually better to use a scalar calculation at the end instead of aligning the buffer to use SIMD.
This has no high impact, since this path is executed very few times.
